### PR TITLE
Fixed bug on "list-records" parameter.

### DIFF
--- a/bin/oai-pmh
+++ b/bin/oai-pmh
@@ -82,7 +82,7 @@ program
   .action((baseUrl, _options) => run(function* listIdentifiers() {
     const options = _.pick(_options, 'metadataPrefix', 'from', 'until', 'set');
     const oaiPmh = new oaiPmhModule.OaiPmh(baseUrl);
-    yield printList(oaiPmh.listIdentifiers(options));
+    yield printList(oaiPmh.listRecords(options));
   }));
 
 program


### PR DESCRIPTION
There was a bug on the command line option "list-records". It was calling the wrong OAI function.