### PR TITLE
bug: return single result instead of iterating

### DIFF
--- a/src/oai-pmh-list.js
+++ b/src/oai-pmh-list.js
@@ -29,6 +29,12 @@ export async function * getOaiListItems (oaiPmh, verb, field, options) {
   })
   const initialParsedResponse = await parseOaiPmhXml(initialResponse.body)
   const initialResult = initialParsedResponse[verb]
+
+  if (initialResult[field] && !initialResult[field].length) {
+    yield initialResult[field]
+    return
+  }
+
   for (const item of initialResult[field]) {
     yield item
   }


### PR DESCRIPTION
This bug can be reproduced when we try to download records from ArXiv on 2021-10-09. This happened earlier for a couple of times.

Issue is that the response has only one record and instead of having a single object in array it return the single object itself.